### PR TITLE
商品詳細ページにて、ユーザーによって表示を変更する様に実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,6 +19,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params

--- a/app/models/days.rb
+++ b/app/models/days.rb
@@ -1,4 +1,4 @@
-class  Day < ActiveHash::Base
+class  Days < ActiveHash::Base
   self.data = [
     { id: 1, name: '--'},
     { id: 2, name: '1~2日で発送'},

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,7 +7,7 @@ class Item < ApplicationRecord
   belongs_to :status
   belongs_to :shipping
   belongs_to :area
-  belongs_to :day
+  belongs_to :days
 
 
   with_options numericality: { other_than: 1 } do

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,7 +129,7 @@
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
     <% @item.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -16,23 +16,23 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%= @item.shipping.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
+    <% if user_signed_in? && current_user.id == @item.user.id%>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% else %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-
+    <% end %>
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
@@ -43,27 +43,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.days.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -22,17 +22,18 @@
         <%= @item.shipping.name %>
       </span>
     </div>
-
+    <% if user_signed_in?%>
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-    <% if user_signed_in? && current_user.id == @item.user.id%>
-      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-      <p class='or-text'>or</p>
-      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-    <% else %>
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-    <% end %>
+      <% if current_user.id == @item.user.id%>
+        <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+        <p class='or-text'>or</p>
+        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <% else %>
+      <%# 商品が売れていない場合はこちらを表示しましょう %>
+        <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <%# //商品が売れていない場合はこちらを表示しましょう %>
+      <% end %>
+    <% end %>  
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -38,7 +38,7 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.explanation %></span>
     </div>
     <table class="detail-table">
       <tbody>
@@ -103,7 +103,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
 
   root to: "items#index"
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 end


### PR DESCRIPTION
 WHY
商品のより詳細の情報が閲覧でき、更に購入や編集・削除の機能を利用できる様にするため。(後に実装)

WHAT 
商品の画像をクリックするとそれぞれの詳細ページに遷移され、現在のユーザーが出品者の場合は編集・削除ボタンを表示し、それ以外（出品者とは別のユーザーもしくはログインしていないユーザー）の場合は購入ボタンを表示させる様にした。